### PR TITLE
Add real-time-safe SPSC ring buffer and denormal-aware delay line

### DIFF
--- a/Containers.Test/DelayLineTests.cs
+++ b/Containers.Test/DelayLineTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.Containers.Tests;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class DelayLineTests
+{
+	[TestMethod]
+	public void Constructor_NonPositiveCapacity_Throws()
+	{
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DelayLine(0));
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DelayLine(-4));
+	}
+
+	[TestMethod]
+	public void Capacity_MatchesRequestedMaxDelay()
+	{
+		DelayLine line = new(100);
+		Assert.AreEqual(100, line.Capacity);
+	}
+
+	[TestMethod]
+	public void NewDelayLine_ReadsZero()
+	{
+		DelayLine line = new(8);
+		for (int delay = 0; delay <= line.Capacity; delay++)
+		{
+			Assert.AreEqual(0f, line.Read(delay));
+		}
+	}
+
+	[TestMethod]
+	public void Read_ReturnsSampleNSamplesInThePast()
+	{
+		DelayLine line = new(8);
+		line.Write(1f);
+		line.Write(2f);
+		line.Write(3f);
+
+		// Delay 0 == most recent, delay 2 == oldest of the three writes.
+		Assert.AreEqual(3f, line.Read(0));
+		Assert.AreEqual(2f, line.Read(1));
+		Assert.AreEqual(1f, line.Read(2));
+	}
+
+	[TestMethod]
+	public void Process_OutputsInputFromExactlyDelaySamplesEarlier()
+	{
+		DelayLine line = new(4);
+		// Process(x, 4) yields x[n - 4]: zero until the line has been primed with 4 samples.
+		Assert.AreEqual(0f, line.Process(10f, 4));
+		Assert.AreEqual(0f, line.Process(20f, 4));
+		Assert.AreEqual(0f, line.Process(30f, 4));
+		Assert.AreEqual(0f, line.Process(40f, 4));
+		Assert.AreEqual(10f, line.Process(50f, 4));
+		Assert.AreEqual(20f, line.Process(60f, 4));
+	}
+
+	[TestMethod]
+	public void Process_ZeroDelay_ReturnsInput()
+	{
+		DelayLine line = new(4);
+		Assert.AreEqual(7f, line.Process(7f, 0));
+		Assert.AreEqual(9f, line.Process(9f, 0));
+	}
+
+	[TestMethod]
+	public void Read_OutOfRange_Throws()
+	{
+		DelayLine line = new(8);
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => line.Read(-1));
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => line.Read(9));
+	}
+
+	[TestMethod]
+	public void ReadInterpolated_HalfwayBetweenSamples_AveragesNeighbours()
+	{
+		DelayLine line = new(8);
+		line.Write(0f);
+		line.Write(10f);
+
+		// delay 0 -> 10 (newest), delay 1 -> 0 (older). 0.5 interpolates halfway.
+		Assert.AreEqual(5f, line.ReadInterpolated(0.5f), 1e-6f);
+	}
+
+	[TestMethod]
+	public void ReadInterpolated_IntegerDelay_MatchesRead()
+	{
+		DelayLine line = new(8);
+		line.Write(3f);
+		line.Write(7f);
+		line.Write(11f);
+
+		Assert.AreEqual(line.Read(1), line.ReadInterpolated(1f), 1e-6f);
+	}
+
+	[TestMethod]
+	public void ReadInterpolated_OutOfRange_Throws()
+	{
+		DelayLine line = new(8);
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => line.ReadInterpolated(-0.5f));
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => line.ReadInterpolated(8.5f));
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => line.ReadInterpolated(float.NaN));
+	}
+
+	[TestMethod]
+	public void Write_FlushesDenormalsToZero()
+	{
+		DelayLine line = new(4);
+		float denormal = float.Epsilon; // smallest subnormal float, well below the threshold
+		line.Write(denormal);
+		Assert.AreEqual(0f, line.Read(0), "Denormal input must be flushed to zero.");
+	}
+
+	[TestMethod]
+	public void Write_KeepsNormalSmallValues()
+	{
+		DelayLine line = new(4);
+		const float audible = 1e-6f; // ~ -120 dBFS, a normal float that must be preserved
+		line.Write(audible);
+		Assert.AreEqual(audible, line.Read(0));
+	}
+
+	[TestMethod]
+	public void Clear_ZeroesAllSamples()
+	{
+		DelayLine line = new(4);
+		line.Write(1f);
+		line.Write(2f);
+		line.Clear();
+
+		for (int delay = 0; delay <= line.Capacity; delay++)
+		{
+			Assert.AreEqual(0f, line.Read(delay));
+		}
+	}
+
+	[TestMethod]
+	public void WrapAround_LongStreamReadsCorrectDelay()
+	{
+		DelayLine line = new(3);
+		float previous = 0f;
+		for (int i = 1; i <= 1000; i++)
+		{
+			// Process(i, 1) returns the value written on the previous call (i - 1), 0 on the first.
+			float output = line.Process(i, 1);
+			Assert.AreEqual(i - 1, output);
+			previous = output;
+		}
+
+		Assert.AreEqual(999f, previous);
+	}
+}

--- a/Containers.Test/SpscRingBufferTests.cs
+++ b/Containers.Test/SpscRingBufferTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.Containers.Tests;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class SpscRingBufferTests
+{
+	[TestMethod]
+	public void Constructor_NonPositiveCapacity_Throws()
+	{
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new SpscRingBuffer<int>(0));
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new SpscRingBuffer<int>(-1));
+	}
+
+	[TestMethod]
+	public void Capacity_IsAtLeastRequested()
+	{
+		SpscRingBuffer<int> buffer = new(5);
+		Assert.IsTrue(buffer.Capacity >= 5, "Usable capacity must be at least the requested amount.");
+	}
+
+	[TestMethod]
+	public void NewBuffer_IsEmpty()
+	{
+		SpscRingBuffer<int> buffer = new(4);
+		Assert.IsTrue(buffer.IsEmpty);
+		Assert.AreEqual(0, buffer.Count);
+		Assert.IsFalse(buffer.TryDequeue(out _));
+	}
+
+	[TestMethod]
+	public void EnqueueDequeue_PreservesFifoOrder()
+	{
+		SpscRingBuffer<int> buffer = new(8);
+		for (int i = 0; i < 5; i++)
+		{
+			Assert.IsTrue(buffer.TryEnqueue(i));
+		}
+
+		for (int i = 0; i < 5; i++)
+		{
+			Assert.IsTrue(buffer.TryDequeue(out int value));
+			Assert.AreEqual(i, value);
+		}
+
+		Assert.IsTrue(buffer.IsEmpty);
+	}
+
+	[TestMethod]
+	public void TryEnqueue_WhenFull_ReturnsFalse()
+	{
+		SpscRingBuffer<int> buffer = new(4);
+		int enqueued = 0;
+		while (buffer.TryEnqueue(enqueued))
+		{
+			enqueued++;
+		}
+
+		Assert.IsTrue(enqueued >= 4, "Should accept at least the requested capacity before reporting full.");
+		Assert.IsFalse(buffer.TryEnqueue(999));
+	}
+
+	[TestMethod]
+	public void TryPeek_DoesNotRemoveElement()
+	{
+		SpscRingBuffer<int> buffer = new(4);
+		buffer.TryEnqueue(42);
+
+		Assert.IsTrue(buffer.TryPeek(out int peeked));
+		Assert.AreEqual(42, peeked);
+		Assert.AreEqual(1, buffer.Count);
+
+		Assert.IsTrue(buffer.TryDequeue(out int dequeued));
+		Assert.AreEqual(42, dequeued);
+	}
+
+	[TestMethod]
+	public void WrapAround_ReusesSlotsCorrectly()
+	{
+		SpscRingBuffer<int> buffer = new(4);
+
+		// Cycle through many more items than capacity to force repeated wraparound.
+		for (int i = 0; i < 1000; i++)
+		{
+			Assert.IsTrue(buffer.TryEnqueue(i));
+			Assert.IsTrue(buffer.TryDequeue(out int value));
+			Assert.AreEqual(i, value);
+		}
+
+		Assert.IsTrue(buffer.IsEmpty);
+	}
+
+	[TestMethod]
+	public async Task ConcurrentProducerConsumer_TransfersAllItemsInOrder()
+	{
+		const int itemCount = 1_000_000;
+		SpscRingBuffer<int> buffer = new(1024);
+
+		Task producer = Task.Run(() =>
+		{
+			int produced = 0;
+			while (produced < itemCount)
+			{
+				if (buffer.TryEnqueue(produced))
+				{
+					produced++;
+				}
+				else
+				{
+					Thread.SpinWait(1);
+				}
+			}
+		});
+
+		Task<bool> consumer = Task.Run(() =>
+		{
+			int expected = 0;
+			while (expected < itemCount)
+			{
+				if (buffer.TryDequeue(out int value))
+				{
+					if (value != expected)
+					{
+						return false;
+					}
+
+					expected++;
+				}
+				else
+				{
+					Thread.SpinWait(1);
+				}
+			}
+
+			return true;
+		});
+
+		await Task.WhenAll(producer, consumer).ConfigureAwait(false);
+		Assert.IsTrue(await consumer.ConfigureAwait(false), "All items must be received exactly once and in order.");
+		Assert.IsTrue(buffer.IsEmpty);
+	}
+
+	[TestMethod]
+	public void Dequeue_ReferenceType_ReleasesReference()
+	{
+		SpscRingBuffer<string> buffer = new(4);
+		buffer.TryEnqueue("hello");
+		Assert.IsTrue(buffer.TryDequeue(out string? value));
+		Assert.AreEqual("hello", value);
+		Assert.IsTrue(buffer.IsEmpty);
+	}
+}

--- a/Containers/DelayLine.cs
+++ b/Containers/DelayLine.cs
@@ -1,0 +1,193 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.Containers;
+
+using System;
+
+/// <summary>
+/// A fixed-capacity, single-channel circular delay line for audio-rate <see cref="float"/> samples.
+/// </summary>
+/// <remarks>
+/// A delay line stores the most recent samples and lets you read any of them back by their age
+/// (the number of samples ago they were written). It is the fundamental building block of delays,
+/// echoes, reverbs, comb/all-pass filters, choruses and flangers.
+///
+/// <para>
+/// <b>Real-time safety.</b> The backing store is allocated once in the constructor. After that,
+/// <see cref="Write(float)"/>, <see cref="Read(int)"/>, <see cref="ReadInterpolated(float)"/> and
+/// <see cref="Process(float, int)"/> never allocate, never take a lock and never block, so they are
+/// safe to call from an audio callback. The buffer is intended to be owned and used by a single
+/// thread (typically the audio thread).
+/// </para>
+///
+/// <para>
+/// <b>Denormal awareness.</b> Feedback delay structures naturally decay towards zero, and on many
+/// CPUs the resulting subnormal (denormal) floating-point values are tens to hundreds of times more
+/// expensive to process, causing audible CPU spikes. Samples are flushed to zero once their
+/// magnitude falls below <see cref="DenormalThreshold"/> on write, keeping the buffer free of
+/// denormals without any audible effect.
+/// </para>
+///
+/// <para>
+/// The internal capacity is rounded up to a power of two so that index wrapping uses a bitwise AND
+/// rather than a modulo.
+/// </para>
+/// </remarks>
+public sealed class DelayLine
+{
+	/// <summary>
+	/// Magnitude at or below which a sample is treated as denormal and flushed to zero on write.
+	/// </summary>
+	/// <remarks>
+	/// The smallest normal <see cref="float"/> is approximately 1.18e-38; this threshold sits well
+	/// above the subnormal range so all denormals are eliminated, while only flushing values far
+	/// below audibility (roughly -600 dBFS).
+	/// </remarks>
+	public const float DenormalThreshold = 1e-30f;
+
+	/// <summary>
+	/// The backing store, whose length is always a power of two.
+	/// </summary>
+	private readonly float[] buffer;
+
+	/// <summary>
+	/// Bitmask equal to <c>buffer.Length - 1</c>, used to wrap indices.
+	/// </summary>
+	private readonly int mask;
+
+	/// <summary>
+	/// Index of the next slot to be written.
+	/// </summary>
+	private int writeIndex;
+
+	/// <summary>
+	/// Gets the maximum delay, in samples, that can be read back from this delay line.
+	/// </summary>
+	public int Capacity { get; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="DelayLine"/> class that can delay a signal by up
+	/// to <paramref name="maxDelaySamples"/> samples.
+	/// </summary>
+	/// <param name="maxDelaySamples">The maximum delay, in samples, the line must support.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxDelaySamples"/> is less than one.</exception>
+	public DelayLine(int maxDelaySamples)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDelaySamples);
+
+		// One extra slot is needed so the oldest readable sample (delay == maxDelaySamples) is not
+		// the slot about to be overwritten.
+		int length = NextPower2(maxDelaySamples + 1);
+		buffer = new float[length];
+		mask = length - 1;
+		Capacity = maxDelaySamples;
+	}
+
+	/// <summary>
+	/// Writes a new sample into the delay line, advancing the write position by one.
+	/// </summary>
+	/// <param name="sample">The sample to store. Denormal magnitudes are flushed to zero.</param>
+	public void Write(float sample)
+	{
+		buffer[writeIndex] = FlushDenormal(sample);
+		writeIndex = (writeIndex + 1) & mask;
+	}
+
+	/// <summary>
+	/// Reads the sample that is <paramref name="delaySamples"/> samples in the past.
+	/// </summary>
+	/// <param name="delaySamples">The delay in samples; <c>0</c> is the most recently written sample and <see cref="Capacity"/> is the oldest.</param>
+	/// <returns>The delayed sample.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="delaySamples"/> is not in the range <c>[0, Capacity]</c>.</exception>
+	/// <remarks>With this convention a delay of <c>d</c> returns <c>x[n - d]</c>, so <see cref="Process(float, int)"/> with a delay of <c>d</c> outputs the input from exactly <c>d</c> samples earlier.</remarks>
+	public float Read(int delaySamples)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(delaySamples);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(delaySamples, Capacity);
+
+		// The most recently written sample sits one slot behind the write cursor (delay 0).
+		int index = (writeIndex - 1 - delaySamples) & mask;
+		return buffer[index];
+	}
+
+	/// <summary>
+	/// Reads a fractionally delayed sample using linear interpolation between adjacent samples.
+	/// </summary>
+	/// <param name="delaySamples">The fractional delay in samples; must lie in the range <c>[0, Capacity]</c>.</param>
+	/// <returns>The linearly interpolated delayed sample.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="delaySamples"/> is not in the range <c>[0, Capacity]</c>.</exception>
+	/// <remarks>
+	/// Linear interpolation is the standard choice for modulated delays (chorus/flanger). For static
+	/// integer delays prefer <see cref="Read(int)"/>, which avoids the interpolation and the high-frequency
+	/// roll-off it introduces.
+	/// </remarks>
+	public float ReadInterpolated(float delaySamples)
+	{
+		if (float.IsNaN(delaySamples) || delaySamples < 0f || delaySamples > Capacity)
+		{
+			throw new ArgumentOutOfRangeException(nameof(delaySamples), delaySamples, $"Delay must be in the range [0, {Capacity}].");
+		}
+
+		int delayInt = (int)delaySamples;
+		float frac = delaySamples - delayInt;
+
+		int index0 = (writeIndex - 1 - delayInt) & mask;
+		// The interpolation partner is one sample older; clamp so we never read past Capacity.
+		int olderDelay = Math.Min(delayInt + 1, Capacity);
+		int index1 = (writeIndex - 1 - olderDelay) & mask;
+
+		float s0 = buffer[index0];
+		float s1 = buffer[index1];
+		return s0 + ((s1 - s0) * frac);
+	}
+
+	/// <summary>
+	/// Writes <paramref name="input"/> and returns the sample delayed by <paramref name="delaySamples"/> in a single call.
+	/// </summary>
+	/// <param name="input">The new sample to store.</param>
+	/// <param name="delaySamples">The delay in samples; must lie in the range <c>[0, Capacity]</c>.</param>
+	/// <returns>The delayed output sample, equal to the input from <paramref name="delaySamples"/> samples earlier.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="delaySamples"/> is not in the range <c>[0, Capacity]</c>.</exception>
+	/// <remarks>This is the common per-sample idiom: push the input, then tap the output.</remarks>
+	public float Process(float input, int delaySamples)
+	{
+		Write(input);
+		return Read(delaySamples);
+	}
+
+	/// <summary>
+	/// Resets the delay line, zeroing all stored samples and the write position.
+	/// </summary>
+	public void Clear()
+	{
+		Array.Clear(buffer, 0, buffer.Length);
+		writeIndex = 0;
+	}
+
+	/// <summary>
+	/// Flushes denormal magnitudes to zero.
+	/// </summary>
+	/// <param name="value">The value to sanitise.</param>
+	/// <returns>Zero if the magnitude is at or below <see cref="DenormalThreshold"/>; otherwise the value unchanged.</returns>
+	private static float FlushDenormal(float value) =>
+		value is < DenormalThreshold and > -DenormalThreshold ? 0f : value;
+
+	/// <summary>
+	/// Calculates the next power of two greater than or equal to the specified value.
+	/// </summary>
+	/// <param name="v">The value to round up.</param>
+	/// <returns>The next power of two.</returns>
+	private static int NextPower2(int v)
+	{
+		v--;
+		v |= v >> 1;
+		v |= v >> 2;
+		v |= v >> 4;
+		v |= v >> 8;
+		v |= v >> 16;
+		v++;
+		return v;
+	}
+}

--- a/Containers/SpscRingBuffer.cs
+++ b/Containers/SpscRingBuffer.cs
@@ -1,0 +1,231 @@
+// Copyright (c) ktsu.dev
+// All rights reserved.
+// Licensed under the MIT license.
+
+namespace ktsu.Containers;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+/// <summary>
+/// A lock-free, wait-free, fixed-capacity single-producer/single-consumer (SPSC) ring buffer.
+/// </summary>
+/// <remarks>
+/// This buffer is designed for handing data across a thread boundary without locks or
+/// allocations on the hot path, which makes it suitable for real-time scenarios such as
+/// publishing meter/scope telemetry from an audio callback to a UI thread.
+///
+/// <para>
+/// <b>Threading contract.</b> Exactly one thread may call the producer operations
+/// (<see cref="TryEnqueue"/>) and exactly one (different or same) thread may call the
+/// consumer operations (<see cref="TryDequeue"/>). Concurrent use by more than one
+/// producer or more than one consumer is undefined behaviour. The producer and consumer
+/// may run fully concurrently with respect to each other.
+/// </para>
+///
+/// <para>
+/// <b>Real-time safety.</b> After construction, neither <see cref="TryEnqueue"/> nor
+/// <see cref="TryDequeue"/> allocates, takes a lock, or blocks. Both are O(1) and never
+/// throw. The producer side is therefore safe to call from an audio/render thread; the
+/// consumer side is intended for the UI/worker thread.
+/// </para>
+///
+/// <para>
+/// Correctness relies on acquire/release ordering: the producer publishes the written
+/// slot by releasing the tail index, and the consumer observes it by acquiring the tail
+/// index (and vice versa for the head index). On the .NET memory model this is provided by
+/// <see cref="Volatile"/> acquire/release reads and writes.
+/// </para>
+///
+/// <para>
+/// One slot is reserved internally to distinguish the full and empty states without a
+/// separate count, so the usable <see cref="Capacity"/> is one less than the (power-of-two)
+/// internal array length.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The type of elements stored in the buffer.</typeparam>
+[SuppressMessage(
+	"Naming",
+	"CA1711:Identifiers should not have incorrect suffix",
+	Justification = "Buffer accurately describes the ring buffer."
+)]
+public sealed class SpscRingBuffer<T>
+{
+	/// <summary>
+	/// The backing store. Its length is always a power of two so that index wrapping can use
+	/// a bitwise AND with <see cref="mask"/> instead of a modulo.
+	/// </summary>
+	private readonly T[] buffer;
+
+	/// <summary>
+	/// Bitmask equal to <c>buffer.Length - 1</c>, used to wrap indices.
+	/// </summary>
+	private readonly int mask;
+
+	/// <summary>
+	/// Index of the next element to be read. Owned by the consumer; read by the producer.
+	/// </summary>
+	private SpscPaddedIndex head;
+
+	/// <summary>
+	/// Index of the next slot to be written. Owned by the producer; read by the consumer.
+	/// </summary>
+	private SpscPaddedIndex tail;
+
+	/// <summary>
+	/// Gets the maximum number of elements the buffer can hold at once.
+	/// </summary>
+	public int Capacity { get; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SpscRingBuffer{T}"/> class able to hold at
+	/// least <paramref name="capacity"/> elements.
+	/// </summary>
+	/// <param name="capacity">The minimum number of elements the buffer must be able to hold.</param>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="capacity"/> is less than one.</exception>
+	public SpscRingBuffer(int capacity)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegativeOrZero(capacity);
+
+		// Reserve one slot to disambiguate full vs empty, then round up to a power of two.
+		int arrayLength = NextPower2(capacity + 1);
+		buffer = new T[arrayLength];
+		mask = arrayLength - 1;
+		Capacity = arrayLength - 1;
+	}
+
+	/// <summary>
+	/// Gets a value indicating whether the buffer currently appears empty.
+	/// </summary>
+	/// <remarks>
+	/// The result is a snapshot and may be stale the moment it is read if the other thread is
+	/// active. It is exact only when observed from the consumer thread with no concurrent producer.
+	/// </remarks>
+	public bool IsEmpty => Volatile.Read(ref head.Value) == Volatile.Read(ref tail.Value);
+
+	/// <summary>
+	/// Gets the approximate number of elements currently stored in the buffer.
+	/// </summary>
+	/// <remarks>
+	/// This is a best-effort snapshot intended for diagnostics/metering. Under concurrent access
+	/// the true count may have changed by the time the value is returned.
+	/// </remarks>
+	public int Count
+	{
+		get
+		{
+			int currentTail = Volatile.Read(ref tail.Value);
+			int currentHead = Volatile.Read(ref head.Value);
+			return (currentTail - currentHead) & mask;
+		}
+	}
+
+	/// <summary>
+	/// Attempts to add an element to the buffer. Must only be called from the single producer thread.
+	/// </summary>
+	/// <param name="item">The element to add.</param>
+	/// <returns><see langword="true"/> if the element was added; <see langword="false"/> if the buffer was full.</returns>
+	/// <remarks>This operation is lock-free, allocation-free, and never blocks or throws.</remarks>
+	public bool TryEnqueue(T item)
+	{
+		// The producer owns Tail, so a plain read is sufficient here.
+		int currentTail = tail.Value;
+		int nextTail = (currentTail + 1) & mask;
+
+		// Full when advancing Tail would collide with the consumer's Head.
+		// Acquire the consumer's published Head.
+		if (nextTail == Volatile.Read(ref head.Value))
+		{
+			return false;
+		}
+
+		buffer[currentTail] = item;
+
+		// Release: publish the written slot to the consumer.
+		Volatile.Write(ref tail.Value, nextTail);
+		return true;
+	}
+
+	/// <summary>
+	/// Attempts to remove and return the oldest element in the buffer. Must only be called from the
+	/// single consumer thread.
+	/// </summary>
+	/// <param name="item">When this method returns <see langword="true"/>, contains the dequeued element; otherwise the default value.</param>
+	/// <returns><see langword="true"/> if an element was removed; <see langword="false"/> if the buffer was empty.</returns>
+	/// <remarks>This operation is lock-free, allocation-free, and never blocks or throws.</remarks>
+	public bool TryDequeue([MaybeNullWhen(false)] out T item)
+	{
+		// The consumer owns Head, so a plain read is sufficient here.
+		int currentHead = head.Value;
+
+		// Empty when Head has caught up to the producer's published Tail. Acquire Tail.
+		if (currentHead == Volatile.Read(ref tail.Value))
+		{
+			item = default;
+			return false;
+		}
+
+		item = buffer[currentHead];
+
+		// Avoid keeping a reference alive for reference types (no-op cost for value types
+		// is negligible and the JIT elides it for non-reference T).
+		buffer[currentHead] = default!;
+
+		// Release: publish the freed slot to the producer.
+		Volatile.Write(ref head.Value, (currentHead + 1) & mask);
+		return true;
+	}
+
+	/// <summary>
+	/// Attempts to return the oldest element without removing it. Must only be called from the
+	/// single consumer thread.
+	/// </summary>
+	/// <param name="item">When this method returns <see langword="true"/>, contains the oldest element; otherwise the default value.</param>
+	/// <returns><see langword="true"/> if an element was available; <see langword="false"/> if the buffer was empty.</returns>
+	public bool TryPeek([MaybeNullWhen(false)] out T item)
+	{
+		int currentHead = head.Value;
+		if (currentHead == Volatile.Read(ref tail.Value))
+		{
+			item = default;
+			return false;
+		}
+
+		item = buffer[currentHead];
+		return true;
+	}
+
+	/// <summary>
+	/// Calculates the next power of two greater than or equal to the specified value.
+	/// </summary>
+	/// <param name="v">The value to round up.</param>
+	/// <returns>The next power of two.</returns>
+	private static int NextPower2(int v)
+	{
+		v--;
+		v |= v >> 1;
+		v |= v >> 2;
+		v |= v >> 4;
+		v |= v >> 8;
+		v |= v >> 16;
+		v++;
+		return v;
+	}
+}
+
+/// <summary>
+/// A 32-bit index padded onto its own cache line to avoid false sharing between the producer and
+/// consumer of a <see cref="SpscRingBuffer{T}"/>.
+/// </summary>
+/// <remarks>
+/// This is a non-generic struct so that it is permitted to carry an explicit layout (a struct nested
+/// in a generic type cannot). The value sits at offset 64 with 64 bytes of trailing padding, isolating
+/// it from any adjacent field on a typical 64-byte cache line.
+/// </remarks>
+[StructLayout(LayoutKind.Explicit, Size = 128)]
+internal struct SpscPaddedIndex
+{
+	[FieldOffset(64)]
+	public int Value;
+}


### PR DESCRIPTION
## Summary

Implements **upstream roadmap item #3** from the .NET VST3 effects host plan: real-time-safe buffers for the audio↔UI boundary and for delay-based DSP. Both types are additive and pre-allocate their backing store so they never allocate, lock, or block on the hot path.

### `SpscRingBuffer<T>`
A lock-free, wait-free, fixed-capacity **single-producer/single-consumer** ring buffer.

- Allocation-free and non-blocking `TryEnqueue` / `TryDequeue` / `TryPeek` — safe to call from an audio/render thread (producer) with a UI/worker thread (consumer).
- Correctness via acquire/release ordering (`Volatile.Read`/`Volatile.Write`); one reserved slot disambiguates full vs empty.
- Head/tail indices are cache-line padded (separate non-generic `[StructLayout(Explicit)]` struct) to avoid false sharing.
- Intended for pushing meter/scope telemetry from the audio callback to the UI thread (see plan §"Real-Time Safety").

### `DelayLine`
A fixed-capacity circular delay line for audio-rate `float` samples.

- Integer (`Read`) and linear-interpolated (`ReadInterpolated`) taps; `Process(input, delay)` is the common write-then-tap idiom.
- `Read(d)` returns `x[n-d]` with `d` in `[0, Capacity]` (delay 0 = most recently written sample), so `Process(x, D)` outputs the input from exactly `D` samples earlier.
- **Denormal-aware**: subnormal magnitudes are flushed to zero on write to avoid the large CPU penalty denormals cause in decaying feedback paths.
- Power-of-two backing store for branch-free index wrapping.

## Testing

Added MSTest coverage for both types (`SpscRingBufferTests`, `DelayLineTests`), including FIFO ordering, full/empty edges, wraparound, denormal flushing, interpolation, argument validation, and a 1M-item concurrent producer/consumer soak test. Full suite: **351/351 passing** locally (`net10.0`).

> Note: the local sandbox only has .NET SDK 10.0.108, which is older than the Roslyn the pinned `ktsu.Sdk` analyzers (2.8.0) require, so tests were run with the standard `dotnet`/MSTest runner against `net10.0`. CI runs the full multi-target build with analyzers and style enforcement.

🤖 Part of the ktsu VST plugin upstream-enablement work.

https://claude.ai/code/session_01JQ3bQMuSYuumAnQZaYUKP7

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ3bQMuSYuumAnQZaYUKP7)_